### PR TITLE
Correctly handle invalid Google project id

### DIFF
--- a/src/main/kotlin/com/plusmobileapps/firebaseadminsample/firebase/FirebaseAuth.kt
+++ b/src/main/kotlin/com/plusmobileapps/firebaseadminsample/firebase/FirebaseAuth.kt
@@ -33,6 +33,13 @@ class FirebaseAuthProvider(config: FirebaseConfig) : AuthenticationProvider(conf
 
             if (principal != null) {
                 context.principal(principal)
+            } else {
+                context.challenge(
+                    FirebaseJWTAuthKey, AuthenticationFailedCause.InvalidCredentials
+                ) { challengeFunc, call ->
+                    challengeFunc.complete()
+                    call.respond(UnauthorizedResponse(HttpAuthHeader.bearerAuthChallenge(realm = FIREBASE_AUTH)))
+                }
             }
         } catch (cause: Throwable) {
             val message = cause.message ?: cause.javaClass.simpleName


### PR DESCRIPTION
Without this change, having the firebase verification throw an exception due to a wrong Google project ID resulted in the endpoints returning 200 OK instead of 401 unauthorized.

I think in general, it is better when a 401 response is automatically returned, instead of having to check for a null principal and return 401 manually in every route.